### PR TITLE
Print the argparse's help documentation if no positional arg passed

### DIFF
--- a/imgflippy/__main__.py
+++ b/imgflippy/__main__.py
@@ -213,14 +213,14 @@ def main():
                              default=argparse.SUPPRESS,
                              dest='outline_color')
 
+    if not sys.argv[1:]:
+        parser_.exit(status=1, message=parser_.print_help())
+
     args = parser_.parse_args()
 
     if hasattr(args, 'version'):
         message = '{} v{}'.format(imgflippy.__name__, imgflippy.__version__)
         parser_.exit(status=0, message=message)
-
-    if not args.cmd:
-        parser_.error(message='too few arguments')
 
     # Display a table of the templates available for captioning.
     if args.cmd == 'get_memes':


### PR DESCRIPTION
Congrats on your OSS! I thought I'd be your first tiny contribution.

When not passing in a positional argument there was a "error: too few arguments" message printed when `parse_args()` is called, and from my tests. Also, I couldn't find the case where `if not args.cmd:` would ever trigger so I removed it

This is what it looks like now
![image](https://user-images.githubusercontent.com/118460/97694666-09e24480-1af7-11eb-80a0-1b4f51c683fd.png)

Previously
![image](https://user-images.githubusercontent.com/118460/97694980-6e9d9f00-1af7-11eb-9d1c-292a8187e662.png)

P.S, if you could throw a `hacktoberfest-accepted` label on this PR for me, even if you reject it, that would help me out! :)

<3 Baz
